### PR TITLE
completed part of admin page(add albums)

### DIFF
--- a/frontend/src/pages/admin/components/AddAlbumDialog.tsx
+++ b/frontend/src/pages/admin/components/AddAlbumDialog.tsx
@@ -1,0 +1,163 @@
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { axiosInstance } from "@/lib/axios";
+import { Plus, Upload } from "lucide-react";
+import { useRef, useState } from "react";
+import toast from "react-hot-toast";
+
+const AddAlbumDialog = () => {
+	const [albumDialogOpen, setAlbumDialogOpen] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+   const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const [newAlbum, setNewAlbum] = useState({
+		title: "",
+		artist: "",
+		releaseYear: new Date().getFullYear(),
+	});
+
+	const [imageFile, setImageFile] = useState<File | null>(null);
+
+    // Function to handle image file selection
+	const handleImageSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (file) {
+			setImageFile(file);
+		}
+	};
+
+    // Function to handle album submission
+	const handleSubmit = async () => {
+		setIsLoading(true);
+
+		try {
+			if (!imageFile) {
+				return toast.error("Please upload an image");
+			}
+
+            // Prepare form data for API request
+			const formData = new FormData();
+			formData.append("title", newAlbum.title);
+			formData.append("artist", newAlbum.artist);
+			formData.append("releaseYear", newAlbum.releaseYear.toString());
+			formData.append("imageFile", imageFile);
+
+            // Send request to create new album
+			await axiosInstance.post("/admin/albums", formData, {
+				headers: {
+					"Content-Type": "multipart/form-data",
+				},
+			});
+
+			setNewAlbum({
+				title: "",
+				artist: "",
+				releaseYear: new Date().getFullYear(),
+			});
+			setImageFile(null);
+			setAlbumDialogOpen(false);
+			toast.success("Album created successfully");
+		} catch (error: any) {
+			toast.error("Failed to create album: " + error.message);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return (
+		<Dialog open={albumDialogOpen} onOpenChange={setAlbumDialogOpen}>
+			<DialogTrigger asChild>
+				<Button className='bg-violet-500 hover:bg-violet-600 text-white'>
+					<Plus className='mr-2 h-4 w-4' />
+					Add Album
+				</Button>
+			</DialogTrigger>
+			<DialogContent className='bg-zinc-900 border-zinc-700'>
+				<DialogHeader>
+					<DialogTitle>Add New Album</DialogTitle>
+					<DialogDescription>Add a new album to your collection</DialogDescription>
+				</DialogHeader>
+				<div className='space-y-4 py-4'>
+					<input
+						type='file'
+						ref={fileInputRef}
+						onChange={handleImageSelect}
+						accept='image/*'
+						className='hidden'
+					/>
+					<div
+						className='flex items-center justify-center p-6 border-2 border-dashed border-zinc-700 rounded-lg cursor-pointer'
+						onClick={() => fileInputRef.current?.click()}
+					>
+						<div className='text-center'>
+							<div className='p-3 bg-zinc-800 rounded-full inline-block mb-2'>
+								<Upload className='h-6 w-6 text-zinc-400' />
+							</div>
+							<div className='text-sm text-zinc-400 mb-2'>
+								{imageFile ? imageFile.name : "Upload album artwork"}
+							</div>
+							<Button variant='outline' size='sm' className='text-xs'>
+								Choose File
+							</Button>
+						</div>
+					</div>
+					<div className='space-y-2'>
+						<label className='text-sm font-medium'>Album Title</label>
+						<Input
+							value={newAlbum.title}
+							onChange={(e) => setNewAlbum({ ...newAlbum, title: e.target.value })}
+							className='bg-zinc-800 border-zinc-700'
+							placeholder='Enter album title'
+						/>
+					</div>
+					<div className='space-y-2'>
+						<label className='text-sm font-medium'>Artist</label>
+						<Input
+							value={newAlbum.artist}
+							onChange={(e) => setNewAlbum({ ...newAlbum, artist: e.target.value })}
+							className='bg-zinc-800 border-zinc-700'
+							placeholder='Enter artist name'
+						/>
+					</div>
+					<div className='space-y-2'>
+						<label className='text-sm font-medium'>Release Year</label>
+						<Input
+							type='number'
+							value={newAlbum.releaseYear}
+							onChange={(e) => setNewAlbum({ ...newAlbum, releaseYear: parseInt(e.target.value) })}
+							className='bg-zinc-800 border-zinc-700'
+							placeholder='Enter release year'
+							min={1900}
+							max={new Date().getFullYear()}
+						/>
+					</div>
+				</div>
+				<DialogFooter>
+                    	{/* Cancel button */}
+					<Button variant='outline' onClick={() => setAlbumDialogOpen(false)} disabled={isLoading}>
+						Cancel
+					</Button>
+
+                    	{/* Submit button to add album */}
+					<Button
+						onClick={handleSubmit}
+						className='bg-violet-500 hover:bg-violet-600'
+						disabled={isLoading || !imageFile || !newAlbum.title || !newAlbum.artist}
+					>
+						{isLoading ? "Creating..." : "Add Album"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+export default AddAlbumDialog;

--- a/frontend/src/pages/admin/components/AlbumsTabContent.tsx
+++ b/frontend/src/pages/admin/components/AlbumsTabContent.tsx
@@ -1,9 +1,34 @@
-const AlbumsTabContent = () => {
-  return (
-    <div>
-      
-    </div>
-  )
-}
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Library } from "lucide-react";
+import AlbumsTable from "./AlbumsTable";
+import AddAlbumDialog from "./AddAlbumDialog";
 
+
+const AlbumsTabContent = () => {
+	return (
+		<Card className='bg-zinc-800/50 border-zinc-700/50'>
+			<CardHeader>
+				<div className='flex items-center justify-between'>
+
+          {/* Section title and description */}
+					<div>
+						<CardTitle className='flex items-center gap-2'>
+							<Library className='h-5 w-5 text-violet-500' />
+							Albums Library
+						</CardTitle>
+						<CardDescription>Manage your album collection</CardDescription>
+					</div>
+          {/* Button to open the "Add Album" dialog */}
+          <AddAlbumDialog />
+				</div>
+			</CardHeader>
+    
+    
+	    {/* Card content displaying the list of albums */}
+			<CardContent>
+				<AlbumsTable />
+			</CardContent>
+		</Card>
+	);
+};
 export default AlbumsTabContent;

--- a/frontend/src/pages/admin/components/AlbumsTable.tsx
+++ b/frontend/src/pages/admin/components/AlbumsTable.tsx
@@ -1,0 +1,75 @@
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useMusicStore } from "@/stores/useMusicStore";
+import { Calendar, Music, Trash2 } from "lucide-react";
+import { useEffect } from "react";
+
+const AlbumsTable = () => {
+	const { albums, deleteAlbum, fetchAlbums } = useMusicStore();
+
+	useEffect(() => {
+		fetchAlbums();
+	}, [fetchAlbums]);
+
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow className='hover:bg-zinc-800/50'>
+					<TableHead className='w-[50px]'></TableHead>
+					<TableHead>Title</TableHead>
+					<TableHead>Artist</TableHead>
+					<TableHead>Release Year</TableHead>
+					<TableHead>Songs</TableHead>
+					<TableHead className='text-right'>Actions</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{albums.map((album) => (
+					<TableRow key={album._id} className='hover:bg-zinc-800/50'>
+						
+                        <TableCell>
+							<img src={album.imageUrl} alt={album.title} className='w-10 h-10 rounded object-cover' />
+						</TableCell>
+
+                        {/* Album title */}
+						<TableCell className='font-medium'>{album.title}</TableCell>
+						
+                        {/* Artist name*/}
+                        <TableCell>{album.artist}</TableCell>
+
+                        {/* Release year with icon */}
+						<TableCell>
+							<span className='inline-flex items-center gap-1 text-zinc-400'>
+								<Calendar className='h-4 w-4' />
+								{album.releaseYear}
+							</span>
+						</TableCell>
+
+                        {/* Number of songs with icon */}
+						<TableCell>
+							<span className='inline-flex items-center gap-1 text-zinc-400'>
+								<Music className='h-4 w-4' />
+								{album.songs.length} songs
+							</span>
+						</TableCell>
+
+                        	{/* Actions column - Delete button */}
+						<TableCell className='text-right'>
+							<div className='flex gap-2 justify-end'>
+								<Button
+									variant='ghost'
+									size='sm'
+									onClick={() => deleteAlbum(album._id)}
+									className='text-red-400 hover:text-red-300 hover:bg-red-400/10'
+								>
+									<Trash2 className='h-4 w-4' />
+								</Button>
+							</div>
+						</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+};
+export default AlbumsTable;


### PR DESCRIPTION
## Summary by Sourcery

This pull request adds the ability to manage albums in the admin page. It introduces components for displaying a table of albums and a dialog for adding new albums.

New Features:
- Implements the ability to add new albums via a dialog form, including fields for title, artist, release year, and image upload.
- Displays a table of albums with columns for the album cover, title, artist, release year, and number of songs.

Enhancements:
- The album table displays the release year and number of songs with associated icons for better readability.
- Uses a store to manage the albums, and provides a method to fetch the albums from the API.